### PR TITLE
Chore: Make x86 a main source

### DIFF
--- a/com.adilhanney.saber.json
+++ b/com.adilhanney.saber.json
@@ -60,7 +60,7 @@
 						"url": "https://api.github.com/repos/saber-notes/saber/releases/latest",
 						"version-query": ".tag_name",
 						"url-query": ".assets[] | select(.name==\"Saber_\" + $version + \"_Linux_x86_64.tar.gz\") | .browser_download_url",
-						"is-main-source": false
+						"is-main-source": true
 					}
 				},
 				{


### PR DESCRIPTION
Arm64 builds are faster now thanks to https://github.com/saber-notes/saber/pull/1437. We can now remove the workaround used to fix https://github.com/flathub-infra/flatpak-external-data-checker/issues/379