### PR TITLE
Chore: Update gnome runtime to 48

### DIFF
--- a/com.adilhanney.saber.json
+++ b/com.adilhanney.saber.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "com.adilhanney.saber",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "46",
+	"runtime-version": "48",
 	"sdk": "org.gnome.Sdk",
 	"command": "saber",
 	"separate-locales": false,


### PR DESCRIPTION
```
Info: runtime org.gnome.Platform branch 46 is end-of-life, with reason:
   The GNOME 46 runtime is no longer supported as of April 17, 2025. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   com.adilhanney.saber
```