### PR TITLE
fix: add zenity module to make file dialogs work

### DIFF
--- a/com.adilhanney.saber.json
+++ b/com.adilhanney.saber.json
@@ -39,6 +39,25 @@
 			]
 		},
 		{
+			"name": "zenity",
+			"buildsystem": "meson",
+			"config-opts": [
+				"--buildtype=release"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://gitlab.gnome.org/GNOME/zenity",
+					"commit": "49f057727f9c215a32397ceb9a7c2782eb4ef474",
+					"tag": "4.1.90",
+					"x-checker-data": {
+						"type": "git",
+						"tag-pattern": "^([\\d.]+)$"
+					}
+				}
+			]
+		},
+		{
 			"name": "saber",
 			"buildsystem": "simple",
 			"build-commands": [


### PR DESCRIPTION
The GNOME runtime [doesn't include zenity](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/elements/freedesktop-sdk.bst#L50), which is used by the file_dialogs flutter library on linux:

```
flutter: SEVERE: ErrorLogger: Exception: Couldn't find the executable zenity in the path.
```

Without zenity, importing/exporting notes, and adding images to notes does not work