### PR TITLE
Improve cleanup commands and more

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y flatpak
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub org.flathub.flatpak-external-data-checker org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08 org.freedesktop.Sdk.Extension.llvm20//25.08 -y
+          flatpak install flathub org.flathub.flatpak-external-data-checker org.gnome.Platform//25.08 org.gnome.Sdk//50 org.freedesktop.Sdk.Extension.llvm20//25.08 -y
 
       # Update saber's tag
       - name: Get PREVIOUS_APP_VERSION

--- a/com.adilhanney.saber.yaml
+++ b/com.adilhanney.saber.yaml
@@ -17,6 +17,10 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --filesystem=xdg-documents/Saber:create
   - --filesystem=xdg-config/kdeglobals:ro
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
 modules:
   - name: libjsoncpp
     buildsystem: meson
@@ -33,11 +37,14 @@ modules:
           version-query: .tag_name
           url-query: .tag_name | "https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/"
             + . + ".tar.gz"
-          is-main-source: false
   - name: zenity
     buildsystem: meson
     config-opts:
-      - --buildtype=release
+      - -Dbuildtype=release
+      - -Dmanpage=false
+    cleanup:
+      - /share/applications
+      - /share/help
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/zenity.git
@@ -81,6 +88,7 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+(?:\+.*)?)$
+          is-main-source: true
       - generated/sources/cargo.json
       - generated/sources/pubspec.json
     modules:

--- a/flatpak-flutter.yaml
+++ b/flatpak-flutter.yaml
@@ -15,6 +15,10 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --filesystem=xdg-documents/Saber:create
   - --filesystem=xdg-config/kdeglobals:ro
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
 modules:
   - name: libjsoncpp
     buildsystem: meson
@@ -31,11 +35,14 @@ modules:
           version-query: .tag_name
           url-query: .tag_name | "https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/"
             + . + ".tar.gz"
-          is-main-source: false
   - name: zenity
     buildsystem: meson
     config-opts:
-      - --buildtype=release
+      - -Dbuildtype=release
+      - -Dmanpage=false
+    cleanup:
+      - /share/applications
+      - /share/help
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/zenity.git
@@ -78,5 +85,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+(?:\+.*)?)$
+          is-main-source: true
     modules:
       - generated/modules/rustup-1.94.0.json


### PR DESCRIPTION
### Improve cleanup commands

- Improve cleanup commands
- Remove the Zenity-related help files (8 MB)

### Mark the main module as main-source

This action doesn't change anything because flathub.json already disables FEDC. At least it fixes the tag.